### PR TITLE
N-API

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,13 +3,23 @@
     "target_name": "capture-window",
     "sources": [ "src/capture-window.cc" ],
     "include_dirs" : [
-      "<!(node -e \"require('nan')\")"
+      "<!@(node -p \"require('node-addon-api').include\")"
     ],
+    "dependencies": [
+      "<!(node -p \"require('node-addon-api').gyp\")"
+    ],
+    "cflags!": [ "-fno-exceptions" ],
+    "cflags_cc!": [ "-fno-exceptions" ],
     "conditions": [
       ["OS==\"mac\"", {
         "libraries": [ "-framework Foundation" ],
+        "cflags+": [ "-fvisibility=hidden" ],
         "xcode_settings": {
-          "OTHER_CFLAGS": [ "-ObjC++" ]
+          "OTHER_CFLAGS": [ "-ObjC++" ],
+          "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
+          "CLANG_CXX_LIBRARY": "libc++",
+          "MACOSX_DEPLOYMENT_TARGET": "10.7",
+          "GCC_SYMBOLS_PRIVATE_EXTERN": "YES"
         }
       }]
     ]

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "fs-temp": "^0.1.1",
-    "nan": "^2.0.5"
+    "node-addon-api": "^1.6.3"
   },
   "devDependencies": {
     "mocha": "^2.1.0",

--- a/src/apple.m
+++ b/src/apple.m
@@ -7,8 +7,8 @@ void CaptureWindowWorker::Execute () {
   uint32_t windowId;
   bool foundWindow = false;
 
-  NSString *nsBundle = [NSString stringWithUTF8String: *bundle];
-  NSString *nsTitle = [NSString stringWithUTF8String: *title];
+  NSString *nsBundle = [NSString stringWithUTF8String: bundle.c_str()];
+  NSString *nsTitle = [NSString stringWithUTF8String: title.c_str()];
 
   NSArray *windows = (NSArray *) CGWindowListCopyWindowInfo(kCGWindowListExcludeDesktopElements,kCGNullWindowID);
 
@@ -23,15 +23,15 @@ void CaptureWindowWorker::Execute () {
   }
 
   if (foundWindow == false) {
-    return SetErrorMessage("Failed to find window");
+    return SetError("Failed to find window");
   }
 
   CGImageRef img = CGWindowListCreateImage(CGRectNull, kCGWindowListOptionIncludingWindow, windowId, kCGWindowImageBoundsIgnoreFraming);
-  CFURLRef url = (__bridge CFURLRef)[NSURL fileURLWithPath:[NSString stringWithUTF8String: *path]];
+  CFURLRef url = (__bridge CFURLRef)[NSURL fileURLWithPath:[NSString stringWithUTF8String: path.c_str()]];
   CGImageDestinationRef destination = CGImageDestinationCreateWithURL(url, kUTTypePNG, 1, NULL);
 
   if (!destination) {
-    return SetErrorMessage("Failed to create CGImageDestination");
+    return SetError("Failed to create CGImageDestination");
   }
 
   CGImageDestinationAddImage(destination, img, nil);
@@ -39,7 +39,7 @@ void CaptureWindowWorker::Execute () {
   CFRelease(destination);
 
   if (!success) {
-    return SetErrorMessage("Failed to write image");
+    return SetError("Failed to write image");
   }
 
 }

--- a/src/base.cc
+++ b/src/base.cc
@@ -1,35 +1,33 @@
 
-class CaptureWindowWorker : public Nan::AsyncWorker {
+#include <napi.h>
+
+class CaptureWindowWorker : public Napi::AsyncWorker {
 public:
-  CaptureWindowWorker (v8::Local<v8::Value> bundle, v8::Local<v8::Value> title, v8::Local<v8::Value> path, Nan::Callback *callback)
-    : Nan::AsyncWorker(callback), bundle(bundle), title(title), path(path) {}
+  CaptureWindowWorker (std::string bundle, std::string title, std::string path, Napi::Function &callback)
+    : Napi::AsyncWorker(callback), bundle(bundle), title(title), path(path) {}
   ~CaptureWindowWorker () {}
 
   void Execute ();
 
-  void HandleOKCallback () {
-    v8::Local<v8::Value> argv[] = {
-      Nan::Null(),
-      Nan::New(*path).ToLocalChecked()
-    };
-
-    callback->Call(2, argv);
+  void OnOK () {
+    Callback().Call({ Env().Null(), Napi::String::New(Env(), path) });
   }
 
 private:
-  Nan::Utf8String bundle;
-  Nan::Utf8String title;
-  Nan::Utf8String path;
+  std::string bundle;
+  std::string title;
+  std::string path;
 };
 
-NAN_METHOD(capture_window) {
-  Nan::Callback *cb = new Nan::Callback(info[3].As<v8::Function>());
-  Nan::AsyncQueueWorker(new CaptureWindowWorker(info[0], info[1], info[2], cb));
+Napi::Value capture_window(const Napi::CallbackInfo &info) {
+  Napi::Function cb = info[3].As<Napi::Function>();
+  (new CaptureWindowWorker(info[0].As<Napi::String>(), info[1].As<Napi::String>(), info[2].As<Napi::String>(), cb))->Queue();
+  return info.Env().Undefined();
 }
 
-NAN_MODULE_INIT(Initialize) {
-  Nan::Set(target, Nan::New("captureWindow").ToLocalChecked(),
-    Nan::GetFunction(Nan::New<v8::FunctionTemplate>(capture_window)).ToLocalChecked());
+Napi::Object Initialize(Napi::Env env, Napi::Object exports) {
+  exports["captureWindow"] = Napi::Function::New(env, capture_window);
+  return exports;
 }
 
-NODE_MODULE(capture_window, Initialize)
+NODE_API_MODULE(capture_window, Initialize)

--- a/src/capture-window.cc
+++ b/src/capture-window.cc
@@ -1,7 +1,4 @@
 
-#include <node.h>
-#include <nan.h>
-
 #include "base.cc"
 
 #ifdef __APPLE__


### PR DESCRIPTION
Currently, capture-window doesn't work on Node 12. This PR fixes that (and prevents any other future V8 API breakages) by converting it to use N-API.